### PR TITLE
JCPWPP-52 | JCPWPP-67 | JCPWPP-68 - Replace custom slider with Swiper, fix Oxygen compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
-        "lucide": "^0.575.0"
+        "lucide": "^0.575.0",
+        "swiper": "^12.1.4"
       },
       "devDependencies": {
         "@babel/core": "^7.28.5",
@@ -6181,6 +6182,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.4.tgz",
+      "integrity": "sha512-bihiwoKMOQwW8FfdUbo1DgkVH25E+4ZELIq0oopL1KTKBteLuaTMi/wwFjMxtlhTkk45k3XQ89D1Fvv0spSqBA==",
+      "funding": [
+        {
+          "type": "custom",
+          "url": "https://sponsors.nolimits4web.com"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nolimits4web"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "webpack-remove-empty-scripts": "^1.1.1"
   },
   "dependencies": {
-    "lucide": "^0.575.0"
+    "lucide": "^0.575.0",
+    "swiper": "^12.1.4"
   }
 }

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -2,25 +2,22 @@
 
 @import "tailwindcss/theme.css" layer(theme) prefix(jcp);
 @import "tailwindcss/utilities.css" layer(utilities) prefix(jcp);
+@import "swiper/css";
+@import "swiper/css/navigation";
 
 @theme {
     --color-accent: #ff503e;
 }
 
-/* --- Container isolation (hidden until JS measures and reveals) --- */
-
-.jcp-combined-components {
-    display: none;
-    overflow: hidden;
-    min-width: 0;
-    box-sizing: border-box;
+/* Give Swiper vertical padding so card shadows aren't clipped by overflow:hidden */
+.jcp-plugin-slider .swiper {
+    padding-top: 8px;
+    padding-bottom: 16px;
 }
 
-/* --- Card Sizing --- */
-
-.jcp-plugin-card {
-    flex: 0 0 var(--jcp-card-width, 300px);
-    min-width: 0;
+/* Cards have padding+border — make Swiper's calculated width include them */
+.jcp-plugin-card.swiper-slide {
+    box-sizing: border-box;
 }
 
 /* --- Shared / CTA --- */
@@ -32,7 +29,7 @@
 /* --- Checkin Card --- */
 
 .jcp-plugin-card__gallery {
-    @apply jcp:relative jcp:w-full jcp:aspect-400/260 jcp:overflow-hidden jcp:bg-[#f3f4f6];
+    @apply jcp:relative jcp:w-full jcp:aspect-400/260 jcp:overflow-hidden jcp:bg-[#f3f4f6] jcp:rounded-lg;
 }
 
 .jcp-plugin-card__gallery-inner {

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -9,6 +9,28 @@
     --color-accent: #ff503e;
 }
 
+/* Force Oxygen's .ct-shortcode wrapper (the flex child of
+   .ct-section-inner-wrap) to fill parent width when our plugin
+   is inside it. Without this, align-items:flex-start makes it
+   shrink-wrap to content and Swiper inflates infinitely. */
+.ct-shortcode:has(.jcp-combined-components) {
+    width: 100%;
+    min-width: 0;
+    align-self: stretch;
+}
+
+/* Belt-and-suspenders: also clamp our own wrappers. */
+.jcp-combined-components,
+.jcp-plugin-slider,
+.jcp-plugin-slider .swiper {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+    align-self: stretch;
+    justify-self: stretch;
+}
+
 /* Give Swiper vertical padding so card shadows aren't clipped by overflow:hidden */
 .jcp-plugin-slider .swiper {
     padding-top: 8px;

--- a/src/js/checkins/checkins-pagination.js
+++ b/src/js/checkins/checkins-pagination.js
@@ -156,9 +156,9 @@ document.addEventListener("DOMContentLoaded", function () {
         }
 
         return `
-        <article class="jcp-plugin-card jcp:group jcp:bg-white jcp:rounded-xl jcp:overflow-hidden jcp:transition-transform jcp:duration-200 jcp:hover:-translate-y-0.5">
+        <article class="jcp-plugin-card swiper-slide jcp:group jcp:bg-white jcp:rounded-2xl jcp:p-2 jcp:border jcp:border-[#e5e7eb] jcp:shadow-[0_1px_3px_rgba(0,0,0,0.04),0_4px_12px_-4px_rgba(0,0,0,0.06)] jcp:transition-transform jcp:duration-200 jcp:hover:-translate-y-0.5">
             ${galleryHtml}
-            <div class="jcp-plugin-card__body jcp:p-6 jcp:border-2 jcp:border-[#e5e7eb] jcp:border-t-0 jcp:rounded-b-xl">
+            <div class="jcp-plugin-card__body jcp:p-4">
                 <p class="jcp-plugin-card__description jcp:text-[17px] jcp:leading-[1.6] jcp:text-[#111827] jcp:mb-2 jcp:line-clamp-4 jcp:overflow-hidden" data-desc-text>${nl2br(checkin.description || '')}</p>
                 <button type="button" class="jcp-plugin-card__toggle jcp:border-0 jcp:bg-transparent jcp:text-accent jcp:text-sm jcp:font-semibold jcp:p-0 jcp:mb-4 jcp:cursor-pointer jcp:hover:underline" data-desc-toggle hidden aria-expanded="false">Read more</button>
                 <div class="jcp-plugin-card__meta jcp:flex jcp:flex-nowrap jcp:items-center jcp:justify-between jcp:gap-2 jcp:pt-4 jcp:border-t jcp:border-[#e5e7eb] jcp:text-sm jcp:text-[#6b7280]">

--- a/src/js/checkins/slider.js
+++ b/src/js/checkins/slider.js
@@ -1,169 +1,53 @@
+import Swiper from 'swiper';
+import { Navigation, Autoplay } from 'swiper/modules';
+
 (function () {
-  var sliderTrack = document.getElementById("jcp-plugin-slider-track");
-  var sliderViewport = sliderTrack ? sliderTrack.parentElement : null;
-  var sliderPrev = document.getElementById("jcp-plugin-slider-prev");
-  var sliderNext = document.getElementById("jcp-plugin-slider-next");
-  var wrapper = document.querySelector(".jcp-combined-components");
-  var sliderContainer = document.querySelector(".jcp-plugin-slider");
-  var currentIndex = 0;
-  var totalCards = 0;
-  var isFirstRun = true;
+  var sliderEl = document.querySelector('.jcp-plugin-slider .swiper');
+  if (!sliderEl) return;
 
-  /**
-   * Read the actual gap from the slider track's computed style.
-   */
-  function getTrackGap() {
-    if (!sliderTrack) return 24;
-    var gap = parseFloat(window.getComputedStyle(sliderTrack).gap);
-    return isNaN(gap) ? 24 : gap;
-  }
+  var swiper = new Swiper(sliderEl, {
+    modules: [Navigation, Autoplay],
+    slidesPerView: 1,
+    spaceBetween: 24,
+    autoplay: {
+      delay: 5000,
+      disableOnInteraction: false,
+      pauseOnMouseEnter: true,
+    },
+    breakpoints: {
+      640: { slidesPerView: 2 },
+      1280: { slidesPerView: 3 },
+    },
+    navigation: {
+      nextEl: '#jcp-plugin-slider-next',
+      prevEl: '#jcp-plugin-slider-prev',
+    },
+    on: {
+      reachEnd: function () {
+        if (typeof window.jcpSliderAutoFetch === 'function') {
+          window.jcpSliderAutoFetch();
+        }
+      },
+    },
+  });
 
-  /**
-   * Read the actual horizontal padding from the slider container.
-   */
-  function getSliderPadding() {
-    if (!sliderContainer) return window.innerWidth >= 768 ? 112 : 80;
-    var styles = window.getComputedStyle(sliderContainer);
-    return parseFloat(styles.paddingLeft) + parseFloat(styles.paddingRight);
-  }
-
-  /**
-   * How many cards should be visible at the current width.
-   */
-  function getVisibleCardCount() {
-    var w = getConstrainedWidth();
-    if (w < 640) return 1;
-    if (w < 1024) return 2;
-    return 3;
-  }
-
-  /**
-   * Measure the parent's real width.
-   * First run: wrapper is display:none (from CSS), parent has no inflating content.
-   * Subsequent runs: wrapper has a pixel width, use position:absolute to re-measure.
-   */
-  function getConstrainedWidth() {
-    if (!wrapper || !wrapper.parentElement) return window.innerWidth;
-    var parent = wrapper.parentElement;
-
-    if (isFirstRun) {
-      // Wrapper is display:none — parent is naturally sized
-      var prevParentWidth = parent.style.width;
-      parent.style.width = "100%";
-      var parentWidth = parent.clientWidth;
-      parent.style.width = prevParentWidth || "";
-      return parentWidth || window.innerWidth;
-    }
-
-    // Subsequent runs: take wrapper out of flow to measure
-    var prevPosition = wrapper.style.position;
-    var prevWidth = wrapper.style.width;
-    var prevParentWidth = parent.style.width;
-    wrapper.style.position = "absolute";
-    wrapper.style.width = "0px";
-    parent.style.width = "100%";
-    var parentWidth = parent.clientWidth;
-    parent.style.width = prevParentWidth || "";
-    wrapper.style.position = prevPosition || "";
-    wrapper.style.width = prevWidth || "";
-    return parentWidth || window.innerWidth;
-  }
-
-  /**
-   * Calculate card widths from the constrained parent width and set as CSS variable.
-   */
-  function updateCardSizing() {
-    if (!sliderViewport || !wrapper) return;
-    var containerWidth = getConstrainedWidth();
-    wrapper.style.width = containerWidth + "px";
-    // Reveal wrapper on first run
-    if (isFirstRun) {
-      wrapper.style.display = "block";
-      isFirstRun = false;
-    }
-    var padding = getSliderPadding();
-    var available = containerWidth - padding;
-    var gap = getTrackGap();
-    var cardsVisible = getVisibleCardCount();
-    var cardWidth = (available - (cardsVisible - 1) * gap) / cardsVisible;
-    cardWidth = Math.max(cardWidth, 100);
-    sliderViewport.style.setProperty("--jcp-card-width", cardWidth + "px");
-  }
-
-  /**
-   * Get the pixel step for sliding one card (card width + gap).
-   */
-  function getCardStepSize() {
-    if (!sliderTrack) return 324;
-    var firstCard = sliderTrack.querySelector(".jcp-plugin-card");
-    if (!firstCard) return 324;
-    return firstCard.offsetWidth + getTrackGap();
-  }
-
-  /**
-   * Recalculate card sizing, card count, clamp index, and update position.
-   */
-  function recalculateSlider() {
-    if (!sliderTrack) return;
-    updateCardSizing();
-    totalCards = sliderTrack.querySelectorAll(".jcp-plugin-card").length;
-    var cardsVisible = getVisibleCardCount();
-    currentIndex = Math.max(
-      0,
-      Math.min(currentIndex, Math.max(0, totalCards - cardsVisible)),
-    );
-    updateSliderPosition();
-    updateSliderButtons(cardsVisible);
-  }
-
-  function updateSliderPosition() {
-    if (!sliderTrack) return;
-    var step = getCardStepSize();
-    sliderTrack.style.transform = "translateX(-" + currentIndex * step + "px)";
-  }
-
-  function updateSliderButtons(cardsVisible) {
-    var visible = cardsVisible || getVisibleCardCount();
-    if (sliderPrev) sliderPrev.disabled = currentIndex <= 0;
-    if (sliderNext)
-      sliderNext.disabled =
-        totalCards <= visible || currentIndex >= totalCards - visible;
-  }
-
-  function slidePrev() {
-    if (currentIndex <= 0) return;
-    currentIndex -= 1;
-    updateSliderPosition();
-    updateSliderButtons();
-  }
-
-  function slideNext() {
-    var visible = getVisibleCardCount();
-    if (totalCards <= visible || currentIndex >= totalCards - visible) return;
-    currentIndex += 1;
-    updateSliderPosition();
-    updateSliderButtons(visible);
-    if (window.jcpSliderAutoFetch && currentIndex >= totalCards - visible * 2) {
-      window.jcpSliderAutoFetch();
-    }
-  }
-
+  // Exposed so pagination can refresh after appending new slides
   window.jcpSliderRefresh = function () {
-    recalculateSlider();
+    swiper.update();
     initCardCarousels();
     initDescriptionToggles();
   };
 
   function initCardCarousels() {
     document
-      .querySelectorAll(".jcp-plugin-card__gallery[data-carousel]")
+      .querySelectorAll('.jcp-plugin-card__gallery[data-carousel]')
       .forEach(function (gallery) {
         if (gallery.dataset.carouselBound) return;
-        gallery.dataset.carouselBound = "1";
-        var slides = gallery.querySelectorAll(".jcp-plugin-card__slide");
-        var prevBtn = gallery.querySelector(".jcp-plugin-card__nav--prev");
-        var nextBtn = gallery.querySelector(".jcp-plugin-card__nav--next");
-        var dots = gallery.querySelectorAll(".jcp-plugin-card__dot");
+        gallery.dataset.carouselBound = '1';
+        var slides = gallery.querySelectorAll('.jcp-plugin-card__slide');
+        var prevBtn = gallery.querySelector('.jcp-plugin-card__nav--prev');
+        var nextBtn = gallery.querySelector('.jcp-plugin-card__nav--next');
+        var dots = gallery.querySelectorAll('.jcp-plugin-card__dot');
         var total = slides.length;
         var active = 0;
         function setActive(i) {
@@ -172,33 +56,33 @@
           active = i;
           slides.forEach(function (slide, idx) {
             if (idx === active) {
-              slide.classList.add("jcp:opacity-100", "jcp:visible");
-              slide.classList.remove("jcp:opacity-0", "jcp:invisible");
+              slide.classList.add('jcp:opacity-100', 'jcp:visible');
+              slide.classList.remove('jcp:opacity-0', 'jcp:invisible');
             } else {
-              slide.classList.add("jcp:opacity-0", "jcp:invisible");
-              slide.classList.remove("jcp:opacity-100", "jcp:visible");
+              slide.classList.add('jcp:opacity-0', 'jcp:invisible');
+              slide.classList.remove('jcp:opacity-100', 'jcp:visible');
             }
           });
           dots.forEach(function (dot, idx) {
             if (idx === active) {
-              dot.classList.add("jcp:bg-white", "jcp:scale-[1.2]");
-              dot.classList.remove("jcp:bg-white/60");
+              dot.classList.add('jcp:bg-white', 'jcp:scale-[1.2]');
+              dot.classList.remove('jcp:bg-white/60');
             } else {
-              dot.classList.add("jcp:bg-white/60");
-              dot.classList.remove("jcp:bg-white", "jcp:scale-[1.2]");
+              dot.classList.add('jcp:bg-white/60');
+              dot.classList.remove('jcp:bg-white', 'jcp:scale-[1.2]');
             }
           });
         }
         if (prevBtn)
-          prevBtn.addEventListener("click", function () {
+          prevBtn.addEventListener('click', function () {
             setActive(active - 1);
           });
         if (nextBtn)
-          nextBtn.addEventListener("click", function () {
+          nextBtn.addEventListener('click', function () {
             setActive(active + 1);
           });
         dots.forEach(function (dot, idx) {
-          dot.addEventListener("click", function () {
+          dot.addEventListener('click', function () {
             setActive(idx);
           });
         });
@@ -206,28 +90,28 @@
   }
 
   function initDescriptionToggles() {
-    document.querySelectorAll(".jcp-plugin-card").forEach(function (card) {
-      var text = card.querySelector("[data-desc-text]");
-      var toggle = card.querySelector("[data-desc-toggle]");
+    document.querySelectorAll('.jcp-plugin-card').forEach(function (card) {
+      var text = card.querySelector('[data-desc-text]');
+      var toggle = card.querySelector('[data-desc-toggle]');
       if (!text || !toggle) return;
       if (!toggle.dataset.bound) {
-        toggle.addEventListener("click", function () {
-          var expanded = text.classList.contains("jcp:line-clamp-none");
+        toggle.addEventListener('click', function () {
+          var expanded = text.classList.contains('jcp:line-clamp-none');
           if (expanded) {
-            text.classList.remove("jcp:line-clamp-none", "jcp:overflow-visible");
-            text.classList.add("jcp:line-clamp-4", "jcp:overflow-hidden");
-            toggle.setAttribute("aria-expanded", "false");
-            toggle.textContent = "Read more";
+            text.classList.remove('jcp:line-clamp-none', 'jcp:overflow-visible');
+            text.classList.add('jcp:line-clamp-4', 'jcp:overflow-hidden');
+            toggle.setAttribute('aria-expanded', 'false');
+            toggle.textContent = 'Read more';
           } else {
-            text.classList.add("jcp:line-clamp-none", "jcp:overflow-visible");
-            text.classList.remove("jcp:line-clamp-4", "jcp:overflow-hidden");
-            toggle.setAttribute("aria-expanded", "true");
-            toggle.textContent = "Show less";
+            text.classList.add('jcp:line-clamp-none', 'jcp:overflow-visible');
+            text.classList.remove('jcp:line-clamp-4', 'jcp:overflow-hidden');
+            toggle.setAttribute('aria-expanded', 'true');
+            toggle.textContent = 'Show less';
           }
         });
-        toggle.dataset.bound = "1";
+        toggle.dataset.bound = '1';
       }
-      if (text.classList.contains("jcp:line-clamp-none")) {
+      if (text.classList.contains('jcp:line-clamp-none')) {
         toggle.hidden = false;
         return;
       }
@@ -237,25 +121,6 @@
     });
   }
 
-  if (sliderPrev) sliderPrev.addEventListener("click", slidePrev);
-  if (sliderNext) sliderNext.addEventListener("click", slideNext);
-
-  function init() {
-    recalculateSlider();
-    initCardCarousels();
-    initDescriptionToggles();
-  }
-
-  // Debounced window resize — no ResizeObserver to avoid infinite loops
-  var resizeTimer;
-  window.addEventListener("resize", function () {
-    clearTimeout(resizeTimer);
-    resizeTimer = setTimeout(recalculateSlider, 100);
-  });
-
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", init);
-  } else {
-    init();
-  }
+  initCardCarousels();
+  initDescriptionToggles();
 })();

--- a/templates/checkin-card.php
+++ b/templates/checkin-card.php
@@ -16,7 +16,7 @@ $has_gallery   = $has_images && count($image_urls) > 1;
 
 ?>
 
-<article class="jcp-plugin-card jcp:group jcp:bg-white jcp:rounded-xl jcp:overflow-hidden jcp:transition-transform jcp:duration-200 jcp:hover:-translate-y-0.5">
+<article class="jcp-plugin-card swiper-slide jcp:group jcp:bg-white jcp:rounded-2xl jcp:p-2 jcp:border jcp:border-[#e5e7eb] jcp:shadow-[0_1px_3px_rgba(0,0,0,0.04),0_4px_12px_-4px_rgba(0,0,0,0.06)] jcp:transition-transform jcp:duration-200 jcp:hover:-translate-y-0.5">
 
     <?php if ($has_images) : ?>
     <div class="jcp-plugin-card__gallery"<?php if ($has_gallery) : ?> data-carousel<?php endif; ?>>
@@ -50,7 +50,7 @@ $has_gallery   = $has_images && count($image_urls) > 1;
     </div>
     <?php endif; ?>
 
-    <div class="jcp-plugin-card__body jcp:p-6 jcp:border-2 jcp:border-[#e5e7eb] jcp:border-t-0 jcp:rounded-b-xl">
+    <div class="jcp-plugin-card__body jcp:p-4">
         <p class="jcp-plugin-card__description jcp:line-clamp-4 jcp:overflow-hidden" data-desc-text><?php echo nl2br(esc_html($checkin['description'] ?? '')); ?></p>
         <button type="button" class="jcp-plugin-card__toggle jcp:border-0 jcp:bg-transparent jcp:text-accent jcp:text-sm jcp:font-semibold jcp:p-0 jcp:cursor-pointer jcp:hover:underline" data-desc-toggle hidden aria-expanded="false">Read more</button>
         <hr class="jcp:border-0 jcp:border-t jcp:border-[#e5e7eb] jcp:my-4">

--- a/templates/checkins-slider.php
+++ b/templates/checkins-slider.php
@@ -10,13 +10,8 @@ if (! defined('ABSPATH')) {
 <section class="jcp-plugin-slider-section jcp:pb-4 jcp:mt-6 jcp:font-['Inter','SF_Pro_Text',-apple-system,BlinkMacSystemFont,'Segoe_UI',sans-serif]" aria-label="Project check-ins">
     <div class="jcp-plugin-slider jcp:relative jcp:px-10 jcp:md:px-14">
 
-        <button type="button" class="jcp-plugin-slider__btn jcp-plugin-slider__btn--prev jcp:left-0" id="jcp-plugin-slider-prev" aria-label="Previous check-ins">
-            <?php echo jcp_icon('chevron-left', 18, 'jcp:block jcp:md:hidden'); ?>
-            <?php echo jcp_icon('chevron-left', 24, 'jcp:hidden jcp:md:block'); ?>
-        </button>
-
-        <div class="jcp-plugin-slider__viewport jcp:w-full jcp:min-w-0 jcp:overflow-hidden">
-            <div class="jcp-plugin-slider__track jcp:flex jcp:gap-6 jcp:transition-transform jcp:duration-350 jcp:ease-[ease] jcp:will-change-transform" id="jcp-plugin-slider-track">
+        <div class="swiper">
+            <div class="swiper-wrapper" id="jcp-plugin-slider-track">
                 <?php foreach ($checkins as $checkin) :
                     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- plugin-controlled template output
                     echo JobCapturePro_Template::render_template('checkin-card', [
@@ -25,6 +20,11 @@ if (! defined('ABSPATH')) {
                 endforeach; ?>
             </div>
         </div>
+
+        <button type="button" class="jcp-plugin-slider__btn jcp-plugin-slider__btn--prev jcp:left-0" id="jcp-plugin-slider-prev" aria-label="Previous check-ins">
+            <?php echo jcp_icon('chevron-left', 18, 'jcp:block jcp:md:hidden'); ?>
+            <?php echo jcp_icon('chevron-left', 24, 'jcp:hidden jcp:md:block'); ?>
+        </button>
 
         <button type="button" class="jcp-plugin-slider__btn jcp-plugin-slider__btn--next jcp:right-0" id="jcp-plugin-slider-next" aria-label="Next check-ins">
             <?php echo jcp_icon('chevron-right', 18, 'jcp:block jcp:md:hidden'); ?>


### PR DESCRIPTION
## Summary
- Replaces ~200 lines of custom slider JS with Swiper.js
- Fixes infinite width inflation in Oxygen Builder flex-column containers
- Card redesign: minimal frame with inset image, single border, soft shadow
- Adds 5-second autoplay (pauses on hover)

## Tickets
- JCPWPP-52: Auto-scroll check-ins every 5 seconds
- JCPWPP-67: Fix page jumping up when scrolling check-ins
- JCPWPP-68: Fix width of image on check-in card

## What changed
- Custom slider → Swiper (Navigation + Autoplay modules)
- Cards: `box-sizing: border-box` with 8px padding for consistent inset look
- Buttons positioned outside `.swiper` (Swiper-recommended pattern)
- `:has(.jcp-combined-components)` targets Oxygen's `.ct-shortcode` wrapper to apply `align-self: stretch` — automates the fix Oxygen docs recommend setting manually, scoped so other shortcodes are unaffected