### PR TITLE
Fix Oxygen flex inflation on sites with extra ct-div-block wrapper

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -1,11 +1,11 @@
 === JobCapturePro ===
 Contributors: jobcapturepro
 Tags: service business, field service, job tracking
-version: 1.1.0
+version: 1.1.6
 Requires at least: 5.0
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 1.0.1
+Stable tag: 1.1.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/jobcapturepro.php
+++ b/jobcapturepro.php
@@ -5,7 +5,7 @@
  * Plugin URI:        https://www.jobcapturepro.com/wordpress-plugin/
  * Description:       Display job check-ins, company information, and interactive maps from your JobCapturePro account. Showcase completed work, customer reviews, and business locations with professional shortcodes.
  * Text Domain:       jobcapturepro
- * Version:           1.1.0
+ * Version:           1.1.6
  * Requires at least: 5.0
  * Tested up to:      6.6
  * Requires PHP:      7.4
@@ -38,7 +38,7 @@ if (! defined('WPINC')) {
 }
 
 // Define plugin constants
-define('JOBCAPTUREPRO_VERSION', '1.1.0');
+define('JOBCAPTUREPRO_VERSION', '1.1.6');
 define('JOBCAPTUREPRO_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('JOBCAPTUREPRO_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('JOBCAPTUREPRO_PLUGIN_BASENAME', plugin_basename(__FILE__));

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -9,11 +9,13 @@
     --color-accent: #ff503e;
 }
 
-/* Force Oxygen's .ct-shortcode wrapper (the flex child of
-   .ct-section-inner-wrap) to fill parent width when our plugin
-   is inside it. Without this, align-items:flex-start makes it
+/* Force any Oxygen wrapper (ct-shortcode, ct-div-block, ct-new-columns)
+   that contains our plugin to fill parent width. Without this,
+   align-items:flex-start on flex-column parents makes wrappers
    shrink-wrap to content and Swiper inflates infinitely. */
-.ct-shortcode:has(.jcp-combined-components) {
+.ct-shortcode:has(.jcp-combined-components),
+.ct-div-block:has(.jcp-combined-components),
+.ct-new-columns:has(.jcp-combined-components) {
     width: 100%;
     min-width: 0;
     align-self: stretch;


### PR DESCRIPTION
## Summary
- Extends the Oxygen flex-inflation fix from `.ct-shortcode` only to also cover `.ct-div-block` and `.ct-new-columns` ancestors
- Some Oxygen sites (e.g. acculevel20stg) wrap shortcodes in an extra `.ct-div-block`, which was the shrink-wrapping element and stayed inflated to 4106px
- Bumps plugin version to 1.1.6