### PR TITLE
Fix map pagination dropping shortcode filters

### DIFF
--- a/includes/class-jobcapturepro-templates.php
+++ b/includes/class-jobcapturepro-templates.php
@@ -354,14 +354,16 @@ class JobCaptureProTemplates
             true
         );
 
+        global $jcp_combined_sc_atts;
+
         wp_localize_script(
             'jobcapturepro-map',
             'jobcaptureproMapData',
             array(
-                // 
+                //
                 'googleMapsApiKey' => esc_js($maps_api_key),
 
-                // 
+                //
                 'baseApiUrl' => JOBCAPTUREPRO_API_BASE_URL,
                 'apiKey' => JobCaptureProAdmin::get_sanitized_api_key(),
 
@@ -380,6 +382,7 @@ class JobCaptureProTemplates
                 'totalPages'  => $map_data['totalPages'] ?? 1,
                 'pageSize'    => $map_data['pageSize'] ?? 100,
                 'companyId'   => $company_info['id'] ?? null,
+                'scAtts'      => $jcp_combined_sc_atts ?? array(),
             )
         );
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-# Usage: bash scripts/release.sh <version>
+# Usage: bash scripts/release.sh <version> [base-branch]
 # Example: bash scripts/release.sh 1.0.8
+# Example: bash scripts/release.sh 1.1.7 fix/some-branch
 
 VERSION="$1"
+BASE_BRANCH="${2:-main}"
 
 if [ -z "$VERSION" ]; then
     echo "Error: version argument required."
@@ -29,10 +31,10 @@ sed_inplace() {
     fi
 }
 
-# Must start from main
-echo "Switching to main and pulling latest..."
-git checkout main
-git pull origin main
+# Must start from the base branch (defaults to main)
+echo "Switching to $BASE_BRANCH and pulling latest..."
+git checkout "$BASE_BRANCH"
+git pull origin "$BASE_BRANCH"
 
 # Ensure working tree is clean
 if ! git diff --quiet || ! git diff --cached --quiet; then

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -256,6 +256,13 @@ async function initJobCaptureProMap() {
           params.set('companyId', jobcaptureproMapData.companyId);
         }
 
+        // Forward shortcode atts (state, etc.) so paginated results match the initial filter
+        const scAtts = jobcaptureproMapData.scAtts || {};
+        Object.entries(scAtts).forEach(([key, value]) => {
+          if (value === null || value === undefined) return;
+          if (String(value).trim() !== '') params.set(key, String(value));
+        });
+
         const url = new URL('map', baseApiUrl);
         params.forEach((value, key) => url.searchParams.set(key, value));
         const response = await fetch(url.toString(), fetchOptions);


### PR DESCRIPTION
## Summary
- Map's `wp_localize_script` now forwards `scAtts` (same pattern the slider already uses)
- `map.js` pagination merges those atts into each `/api/map?page=N` request
- Fixes paginated map markers ignoring `state` (and other shortcode filters)
